### PR TITLE
bug fixes

### DIFF
--- a/lib/smartcomments.js
+++ b/lib/smartcomments.js
@@ -205,7 +205,7 @@ var esprima = require('esprima'),
          * @return {object} e.g., { name: '@param', value: '{string} commentLine - the src ...'}
          */
         parseTagNameValue: function(commentLine) {
-            var clean = commentLine.replace(/^\s*\*?\s*/, ''),    // strip leading ' * '
+            var clean = commentLine.replace(/^\s*\*?\s?/, ''),    // strip leading ' * '
                 nameValueMatch = /^(?:(@\w+)\s+)?([^\r\n]*)/.exec(clean);
 
             return {
@@ -225,11 +225,18 @@ var esprima = require('esprima'),
          * @return {boolean} true if the two describe the same parameter.  otherwise, false.
          */
         isSameParam: function(srcValue, genValue) {
-            var stripTypeRe = /\{\w*\}/,
-                matchValRe = /^\s*(\w+)/;
+            var stripTypeRe = /\{[\w:-]*\}/,
+                matchValRe = /^\s*([\w:-]+)/;
             srcValue = srcValue.replace(stripTypeRe, '');
             genValue = genValue.replace(stripTypeRe, '');
-            return (matchValRe.exec(srcValue)[1] === matchValRe.exec(genValue)[1]);
+            srcValue = matchValRe.exec(srcValue);
+            genValue = matchValRe.exec(genValue);
+
+            if (srcValue) {
+                return (genValue && srcValue[1] === genValue[1]);
+            } else {
+                return !genValue;
+            }
         },
 
 


### PR DESCRIPTION
don't gobble up whitespace in front of non-tag comment lines
allow parameter names to have colon and dash (':', '-')
if a parameter name has something really weird in it, don't throw an
    exception - return false if we failed to determine if the parameters
    are the same one or not (i.e., duplicate the allow both source and
    generated @param line)
