### PR TITLE
file_name property added to template. 

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -72,7 +72,7 @@ var smartcomments = require('./smartcomments'),
 
                             code = fs.readFileSync(d, 'utf8');
                             if (code.length > 0) {
-                                result = smartcomments.generate(code, config);
+                                result = smartcomments.generate(code, config, d);
 
                                 if (!result.error) {
                                     instance.saveResult(config, code, d, result);

--- a/lib/smartcomments.js
+++ b/lib/smartcomments.js
@@ -73,7 +73,7 @@ var esprima = require('esprima'),
        
         },
 
-        generate: function(source, config) {
+        generate: function(source, config, fileName) {
             var instance = SmartComments,
                 ast,
                 result = {};
@@ -92,6 +92,8 @@ var esprima = require('esprima'),
                 };
             }
             if (ast) {
+                instance.template.file_name = fileName;
+
                 instance.comments_list = [];
 
                 instance.template.setCommentsList(instance.comments_list);


### PR DESCRIPTION
The file name now can be used inside jsdocs comments.
It was needed, for example, inside AMD modules to find global namespace this module is and what will be full constructor name returned by this module.
